### PR TITLE
Solves #17

### DIFF
--- a/core/src/com/oliveshark/pathworks/framework/entities/Agent.java
+++ b/core/src/com/oliveshark/pathworks/framework/entities/Agent.java
@@ -33,10 +33,10 @@ public class Agent {
     public void draw(ShapeRenderer renderer) {
         renderer.setColor(color);
 
-        int halfWidth = (GRID_WIDTH >> 1);
+        int halfWidth = (TILE_DIMENSION >> 1);
 
-        float posXCenter = position.x * TILE_DIMENSION + halfWidth;
-        float posYCenter = position.y * TILE_DIMENSION + halfWidth;
+        float posXCenter = position.x + halfWidth;
+        float posYCenter = position.y + halfWidth;
 
         // Agent
         renderer.circle(posXCenter, posYCenter, halfWidth);
@@ -45,9 +45,8 @@ public class Agent {
             return;
         }
 
-
-        float destXCenter = destination.x * TILE_DIMENSION + halfWidth;
-        float destYCenter = destination.y * TILE_DIMENSION + halfWidth;
+        float destXCenter = destination.x + halfWidth;
+        float destYCenter = destination.y + halfWidth;
 
         Position<Float> triangleTop = new Position<>(destXCenter, destYCenter + halfWidth);
         Position<Float> triangleLeft = new Position<>(destXCenter - halfWidth, destYCenter - halfWidth);

--- a/core/src/com/oliveshark/pathworks/framework/grid/Grid.java
+++ b/core/src/com/oliveshark/pathworks/framework/grid/Grid.java
@@ -11,7 +11,6 @@ import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.oliveshark.pathworks.core.Position;
 import com.oliveshark.pathworks.framework.entities.Agent;
-import com.oliveshark.pathworks.framework.grid.util.PositionUtil;
 import com.oliveshark.pathworks.framework.grid.util.Rectangle;
 
 import java.util.ArrayList;

--- a/core/src/com/oliveshark/pathworks/framework/grid/Grid.java
+++ b/core/src/com/oliveshark/pathworks/framework/grid/Grid.java
@@ -11,6 +11,8 @@ import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.oliveshark.pathworks.core.Position;
 import com.oliveshark.pathworks.framework.entities.Agent;
+import com.oliveshark.pathworks.framework.grid.util.PositionUtil;
+import com.oliveshark.pathworks.framework.grid.util.Rectangle;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -18,6 +20,7 @@ import java.util.Collection;
 import static com.oliveshark.pathworks.config.Config.*;
 import static com.oliveshark.pathworks.framework.grid.util.PositionUtil.getGridPositionFromScreenPosition;
 import static com.oliveshark.pathworks.framework.grid.util.PositionUtil.getPositionFromGridPosition;
+import static com.oliveshark.pathworks.framework.grid.util.Rectangle.createSquare;
 
 public class Grid extends Actor implements InputProcessor {
 
@@ -104,9 +107,11 @@ public class Grid extends Actor implements InputProcessor {
     }
 
     private void reverseCells() {
-        for (Cell[] col : cells) {
-            for (Cell cell : col) {
-                cell.toggleOccupied();
+        for (int i = 0; i < cells.length; ++i) {
+            for (int j = 0; j < cells[i].length; ++j) {
+                if (!hasAgentOnTile(getPositionFromGridPosition(i, j))) {
+                    cells[i][j].toggleOccupied();
+                }
             }
         }
     }
@@ -124,21 +129,21 @@ public class Grid extends Actor implements InputProcessor {
         Cell cell = cells[cellPos.x][cellPos.y];
 
         if (button == Input.Buttons.RIGHT) {
-            if (cellOccupied(cellPos) || hasAgentOnPosition(cellPos)) {
+            if (cellOccupied(cellPos) || hasAgentOnTile(cellPos)) {
                 return false;
             }
             if (secondRightClick) {
-                currentAgent.setDestination(cellPos);
+                currentAgent.setDestination(getPositionFromGridPosition(cellPos));
                 currentAgent = null;
                 secondRightClick = false;
             } else {
-                currentAgent = new Agent(cellPos);
+                currentAgent = new Agent(getPositionFromGridPosition(cellPos));
                 agents.add(currentAgent);
                 secondRightClick = true;
             }
             return false;
         } else if (button == Input.Buttons.LEFT) {
-            if (hasAgentOnPosition(cellPos)) {
+            if (hasAgentOnTile(cellPos)) {
                 return false;
             }
             cell.toggleOccupied();
@@ -152,10 +157,20 @@ public class Grid extends Actor implements InputProcessor {
         return false;
     }
 
-    private boolean hasAgentOnPosition(Position<Integer> agentPos) {
+    private boolean hasAgentOnTile(Position<Integer> tilePos) {
+        Rectangle rect = createSquare(tilePos, TILE_DIMENSION);
         for (Agent agent : agents) {
-            if (agentPos.equals(agent.getPosition()) || agentPos.equals(agent.getDestination())) {
+            Position<Integer> agentPos = agent.getPosition();
+            Rectangle agentRect = createSquare(agentPos, TILE_DIMENSION);
+            if (rect.overlaps(agentRect)) {
                 return true;
+            }
+            Position<Integer> destPos = agent.getDestination();
+            if (destPos != null) {
+                Rectangle destRect = createSquare(destPos, TILE_DIMENSION);
+                if (rect.overlaps(destRect)) {
+                    return true;
+                }
             }
         }
         return false;
@@ -178,8 +193,8 @@ public class Grid extends Actor implements InputProcessor {
         if (!mouseLeftButtonDown)
             return true;
         Position<Integer> cellPos = getGridPositionFromScreenPosition(screenX, screenY);
-        if (hasAgentOnPosition(cellPos)) {
-            return false;
+        if (hasAgentOnTile(getPositionFromGridPosition(cellPos))) {
+            return true;
         }
         cells[cellPos.x][cellPos.y].setOccupied(mouseLeftButtonDownToggle);
         updateMousePos(screenX, screenY);

--- a/core/src/com/oliveshark/pathworks/framework/grid/util/PositionUtil.java
+++ b/core/src/com/oliveshark/pathworks/framework/grid/util/PositionUtil.java
@@ -21,6 +21,10 @@ public class PositionUtil {
         return new Position<>(cellX, cellY);
     }
 
+    public static Position<Integer> getPositionFromGridPosition(Position<Integer> pos) {
+        return getPositionFromGridPosition(pos.x, pos.y);
+    }
+
     public static Position<Integer> getPositionFromGridPosition(int x, int y) {
         return new Position<>(x * TILE_DIMENSION, y * TILE_DIMENSION);
     }

--- a/core/src/com/oliveshark/pathworks/framework/grid/util/Rectangle.java
+++ b/core/src/com/oliveshark/pathworks/framework/grid/util/Rectangle.java
@@ -6,7 +6,10 @@ import java.util.Objects;
 
 public class Rectangle {
 
-    private int x, y, w, h;
+    private int x;
+    private int y;
+    private int w;
+    private int h;
 
     public Rectangle(int x, int y, int w, int h) {
         this.x = x;

--- a/core/src/com/oliveshark/pathworks/framework/grid/util/Rectangle.java
+++ b/core/src/com/oliveshark/pathworks/framework/grid/util/Rectangle.java
@@ -1,0 +1,50 @@
+package com.oliveshark.pathworks.framework.grid.util;
+
+import com.oliveshark.pathworks.core.Position;
+
+import java.util.Objects;
+
+public class Rectangle {
+
+    private int x, y, w, h;
+
+    public Rectangle(int x, int y, int w, int h) {
+        this.x = x;
+        this.y = y;
+        this.w = w;
+        this.h = h;
+    }
+
+    public Rectangle(Position<Integer> pos, int w, int h) {
+        this(pos.x, pos.y, w, h);
+    }
+
+    public static Rectangle createSquare(int x, int y, int dim) {
+        return new Rectangle(x, y, dim, dim);
+    }
+
+    public static Rectangle createSquare(Position<Integer> pos, int dim) {
+        return new Rectangle(pos, dim, dim);
+    }
+
+    public boolean overlaps(Rectangle r) {
+        return !(x + w <= r.x || x >= r.x + r.w
+                || y <= r.y - r.h || y - h >= r.y);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Rectangle rectangle = (Rectangle) o;
+        return x == rectangle.x &&
+                y == rectangle.y &&
+                w == rectangle.w &&
+                h == rectangle.h;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(x, y, w, h);
+    }
+}

--- a/core/test/com/oliveshark/pathworks/framework/grid/util/TestRectangle.java
+++ b/core/test/com/oliveshark/pathworks/framework/grid/util/TestRectangle.java
@@ -1,0 +1,18 @@
+package com.oliveshark.pathworks.framework.grid.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestRectangle {
+
+    @Test
+    public void testOverlap() {
+        Rectangle r1 = new Rectangle(0, 0, 32, 32);
+        Rectangle r2 = new Rectangle(33, 0, 32, 32);
+        Rectangle r3 = new Rectangle(15, 0, 32, 32);
+
+        Assertions.assertTrue(r1.overlaps(r3));
+        Assertions.assertTrue(r2.overlaps(r3));
+        Assertions.assertFalse(r1.overlaps(r2));
+    }
+}


### PR DESCRIPTION
We now check for agent/tile overlap using AABBs. This is to handle
cases when agents aren't right on a tile. Eg. They have moved.
This can also be used when checking collisions later on.
Agents don't have 'grid positions' any longer. They now have screen
positions. This is also to allow them to move smoothly.